### PR TITLE
feat: prevents addFriend adding duplicates

### DIFF
--- a/src/clients/dynamo-users.client.ts
+++ b/src/clients/dynamo-users.client.ts
@@ -169,9 +169,12 @@ export async function addFriendIDToUser(
     Key: {
       username: currentUsername,
     },
-    ExpressionAttributeValues: { ":friendId": [username] },
+    ExpressionAttributeValues: {
+      ":friendId": [username],
+      ":friendIdStr": username,
+    },
     UpdateExpression: "set friends = list_append (friends, :friendId)",
-    ConditionExpression: "not contains (friends, :friendId)",
+    ConditionExpression: "not contains (friends, :friendIdStr)",
   };
 
   return await new Promise(


### PR DESCRIPTION
addFriend endpoint was incorrectly adding duplicate users to the friends list. While this should be prevented on the FE as well, have prevented it on the BE.