### PR TITLE
Feat/add display name and handle

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -96,6 +96,14 @@ functions:
           cors: true
           authorizer: authorizerFunc
     handler: src/handlers/post.addFriend
+  addDisplayName:
+    events:
+      - http:
+          path: addDisplayName
+          method: post
+          cors: true
+          authorizer: authorizerFunc
+    handler: src/handlers/post.addDisplayName
   searchUsers:
     events:
       - http:

--- a/src/handlers/post.ts
+++ b/src/handlers/post.ts
@@ -5,7 +5,10 @@ import {
   APIGatewayProxyResult,
 } from "aws-lambda/trigger/api-gateway-proxy";
 import { isDefined } from "../common/support";
-import { addFriendIDToUser } from "../clients/dynamo-users.client";
+import {
+  addFriendIDToUser,
+  addDisplayNameToUser,
+} from "../clients/dynamo-users.client";
 import { updateAnswer } from "../clients/dynamo-bingo-answers.client";
 import { bingoAnswersMap } from "../types/dynamo.type";
 
@@ -19,7 +22,26 @@ export const addFriend: APIGatewayProxyHandler = async (event) => {
   if (!isDefined(body.friendUsername)) {
     return { statusCode: 500, body: "No body param: friendUsername" };
   }
-  await addFriendIDToUser(claimedUserName, body.friendUsername).then(
+  return await addFriendIDToUser(claimedUserName, body.friendUsername).then(
+    (success) => {
+      return success;
+    },
+    (err) => {
+      return err;
+    }
+  );
+};
+
+// For third party sign-in
+// Need user friendly displayName
+export const addDisplayName: APIGatewayProxyHandler = async (event) => {
+  const claimedUserName = event.requestContext.authorizer.principalId;
+  const body = JSON.parse(event.body);
+
+  if (!isDefined(body.displayName)) {
+    return { statusCode: 500, body: "No body param: displayName" };
+  }
+  return await addDisplayNameToUser(claimedUserName, body.displayName).then(
     (success) => {
       return success;
     },

--- a/src/types/dynamo.type.ts
+++ b/src/types/dynamo.type.ts
@@ -3,6 +3,7 @@
 // username - primary key
 export type usersCollection = {
   username: string;
+  displayName?: string;
   email: string;
   status: "free" | "paid" | "admin";
   friends: friends[];


### PR DESCRIPTION
Adds endpoint to allow users to add a displayName. This was necessary due to the structure of the username coming from the Facebook supplied users, meaning we had to allow users to pick a more user-friendly displayName in order to add/be added by friends.

Updates the search endpoint to check conditionally for displayName and if not available then use username.